### PR TITLE
Add task manager prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-"# daylift" 
+# Daylift Prototype
+
+Dieses Repository enthält ein einfaches Python-Skript `task_manager.py`, mit dem Aufgaben über die Kommandozeile verwaltet werden können. Eine Aufgabe wird per Texteingabe erfasst, an die OpenAI-API gesendet und der geschätzte Aufwand in einer SQLite-Datenbank gespeichert.
+
+## Voraussetzungen
+
+- Python 3.9 oder neuer
+- Abhängigkeiten installieren:
+  ```bash
+  pip install openai
+  ```
+- Die Umgebungsvariable `OPENAI_API_KEY` muss gesetzt sein.
+
+## Nutzung
+
+Das Skript kann direkt ausgeführt werden:
+
+```bash
+python task_manager.py
+```
+
+Nach Eingabe einer Aufgabenbeschreibung werden ähnliche Einträge aus der Datenbank angezeigt und der Aufwandsschätzung von OpenAI ausgegeben. Anschließend wird die Aufgabe gespeichert.
+
+Die gespeicherten Aufgaben werden in der Datei `tasks.db` angelegt.

--- a/task_manager.py
+++ b/task_manager.py
@@ -1,0 +1,75 @@
+import os
+import sqlite3
+import openai
+from datetime import datetime
+
+DB_PATH = 'tasks.db'
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            description TEXT NOT NULL,
+            effort_estimate TEXT,
+            created_at TEXT NOT NULL
+        )
+    ''')
+    conn.commit()
+    conn.close()
+
+def save_task(description, effort):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'INSERT INTO tasks (description, effort_estimate, created_at) VALUES (?,?,?)',
+        (description, effort, datetime.utcnow().isoformat())
+    )
+    conn.commit()
+    conn.close()
+
+def find_similar(description):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('SELECT description FROM tasks WHERE description LIKE ?', ('%'+description+'%',))
+    results = [row[0] for row in c.fetchall()]
+    conn.close()
+    return results
+
+def query_openai(task_text):
+    api_key = os.getenv('OPENAI_API_KEY')
+    if not api_key:
+        raise RuntimeError('OPENAI_API_KEY not set')
+    openai.api_key = api_key
+    prompt = f"Schätze den Aufwand für folgende Aufgabe: '{task_text}'"
+    response = openai.ChatCompletion.create(
+        model='gpt-3.5-turbo',
+        messages=[{'role': 'user', 'content': prompt}]
+    )
+    answer = response.choices[0].message.content.strip()
+    return answer
+
+def main():
+    init_db()
+    print('Beschreibe deine Aufgabe:')
+    description = input().strip()
+    if not description:
+        print('Keine Aufgabe eingegeben.')
+        return
+    print('Sende Aufgabe an OpenAI...')
+    effort = query_openai(description)
+    similar = find_similar(description)
+    save_task(description, effort)
+    print('\nGeschätzter Aufwand:')
+    print(effort)
+    if similar:
+        print('\nÄhnliche Aufgaben in der Datenbank:')
+        for s in similar:
+            print('-', s)
+    else:
+        print('\nKeine ähnlichen Aufgaben gefunden.')
+    print('\nAufgabe wurde gespeichert.')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `task_manager.py` to record a task, query OpenAI for an effort estimate, check for similar tasks and store it in SQLite
- document how to use the prototype in `README.md`

## Testing
- `python -m py_compile task_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68417b2a6748832c802646f0016c61b0